### PR TITLE
feat: SYGN-13298 add get vasp/usage

### DIFF
--- a/api.go
+++ b/api.go
@@ -322,3 +322,18 @@ func (api *BridgeAPI) GetVASPDetails(vaspCode string, validate bool, isProdEnv .
 
 	return VASPDataObject, nil
 }
+
+// GetVASPUsage Get VASP usage by timestamp
+func (api *BridgeAPI) GetVASPUsage(startAt, endAt int64) (*orderedmap.OrderedMap, error) {
+	param := req.Param{
+		"start_at": startAt,
+		"end_at":   endAt,
+	}
+	response, err := request(api, get, "v2/bridge/vasp/usage", param)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return response.(*orderedmap.OrderedMap), nil
+}


### PR DESCRIPTION
新增 GET /vasp/usage
 
 **PR Summary by Typo**
------------

 **Summary**
Introduced `GetVASPUsage` function in `api.go` for retrieving VASP usage data between given timestamps as an `orderedmap.OrderedMap`.

**Key Points**

1. New function `GetVASPUsage` added to `api.go`.
2. Retrieves VASP usage data via HTTP request.
3. Returns response as `orderedmap.OrderedMap`. 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>