### PR TITLE
fix: handle error earlier in parseResponse process

### DIFF
--- a/api.go
+++ b/api.go
@@ -27,11 +27,12 @@ func isHTTPStatusOK(statusCode int) bool {
 }
 
 func parseResponse(r *req.Resp, err error) (interface{}, error) {
-	resp := r.Response()
-	statusCode := resp.StatusCode
 	if err != nil {
 		return nil, err
 	}
+
+	resp := r.Response()
+	statusCode := resp.StatusCode
 
 	m := orderedmap.New()
 	// if err is nil, the response would be json format


### PR DESCRIPTION
 **PR Summary by Typo**
------------

 **Summary**

* Removed redundant line in `parseResponse` function for status code.

**Key Points**

* Redundant line removal for code simplification.
* Functionality remains unchanged. 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>